### PR TITLE
Translate docs and UI to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 # FTPCluster
 
-**Zentrale FTP-Benutzerverwaltung mit Proxy-Zugriff auf mehrere Server über eine einzige IP-Adresse.**
+**Central FTP user management with proxy access to multiple servers through a single IP address.**
 
 ---
 
 ## Features
 
-* Webinterface zur Benutzer- und Serververwaltung
-* Benutzer-Zugriffsrechte pro Server konfigurierbar
-* Zentrale Authentifizierung mit Passwort-Hashing
-* Zugriff über zentrale IP per Proxy-Routing
-* Virtuelle Subfolder für Benutzer gemäß Server-Zuweisung
+* Web interface for managing users and servers
+* User access rights configurable per server
+* Central authentication with password hashing
+* Access via a single IP through proxy routing
+* Virtual subfolders for users based on server assignment
 
 ---
 
-## Projektstruktur
+## Project Structure
 
 ```text
 ftpcluster/
-├── main.py          # FastAPI App & Routing
-├── db.py            # SQLite Setup
-├── models.py        # SQLAlchemy Modelle
-├── ftp_sync.py      # FTP Benutzerverwaltung
-├── proxy.py         # Proxyzugriff via zentrale IP
-├── templates/       # HTML UI via Jinja2
+├── main.py          # FastAPI app and routing
+├── db.py            # SQLite setup
+├── models.py        # SQLAlchemy models
+├── ftp_sync.py      # FTP user management
+├── proxy.py         # Proxy access via central IP
+├── templates/       # HTML UI with Jinja2
 ├── static/          # CSS/JS
-└── README.md        # Diese Datei
+└── README.md        # This file
 ```
 
 ---
 
 ## Setup
 
-### Voraussetzungen
+### Requirements
 
 * Python 3.11+
-* FTP oder SFTP-Server erreichbar
+* Reachable FTP or SFTP server
 
 ### Installation
 
@@ -48,9 +48,9 @@ uvicorn main:app --host 0.0.0.0 --port 8080
 
 ---
 
-## Beispiel
+## Example
 
-Benutzer "user1" hat Zugriff auf Server2 und Server3. Nach dem Login:
+User "user1" has access to Server2 and Server3. After logging in:
 
 ```
 /home/user1/
@@ -58,54 +58,54 @@ Benutzer "user1" hat Zugriff auf Server2 und Server3. Nach dem Login:
 └── server3/
 ```
 
-Zugriffe wie:
+Requests such as:
 
 ```
 /ftp/user1/server2/path/to/file.txt
 ```
 
-werden intern zu Server2 geroutet.
+are internally routed to Server2.
 
 ---
 
-## API (Auswahl)
+## API (selection)
 
 ### Auth
 
 * `POST /login`
 * `GET /logout`
 
-### Benutzerverwaltung
+### User management
 
 * `GET /users`
 * `POST /users`
 
-### Serververwaltung
+### Server management
 
 * `GET /servers`
 * `POST /servers`
 
-### Proxy-Zugriff
+### Proxy access
 
 * `GET /ftp/{username}/{server_alias}/{path:path}`
 
 ---
 
-## Sicherheit
+## Security
 
-* Passwörter gehashed mit bcrypt
-* Admin- und Benutzerpasswörter werden verschlüsselt gespeichert (Fernet)
-* Signierte Login-Cookies über `SECRET_KEY`
-* Optional: HTTPS mit TLS-Zertifikat
+* Passwords hashed with bcrypt
+* Admin and user passwords stored encrypted (Fernet)
+* Signed login cookies via `SECRET_KEY`
+* Optional: HTTPS with TLS certificate
 
 ---
 
-## Lizenz
+## License
 
 MIT
 
 ---
 
-## Autor
+## Author
 
 AsaTyr // 2025

--- a/admin-guide.md
+++ b/admin-guide.md
@@ -1,38 +1,38 @@
 # Admin Guide
 
-Dieses Dokument beschreibt, wie die FTPCluster-Instanz installiert wird und wie Administratoren neue FTP-Server einbinden.
+This document describes how to install the FTPCluster instance and how administrators can add new FTP servers.
 
-## Installation des Servers
+## Installing the server
 
-1. **Voraussetzungen**
-   - Python 3.11 oder neuer
-   - Zugriff auf mindestens einen FTP- oder SFTP-Server
+1. **Prerequisites**
+   - Python 3.11 or newer
+   - Access to at least one FTP or SFTP server
 
-2. **Abhängigkeiten installieren**
+2. **Install dependencies**
    ```bash
    pip install -r requirements.txt
    ```
 
-3. **Umgebungsvariablen setzen**
+3. **Set environment variables**
    ```bash
    export SECRET_KEY=<zufaelliger_wert>
    export FERNET_KEY=$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')
    ```
 
-4. **Datenbank erstellen und Anwendung starten**
+4. **Create the database and start the application**
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8080
    ```
-   Beim ersten Start wird die SQLite-Datenbank `ftpcluster.db` automatisch angelegt.
+   On first start the SQLite database `ftpcluster.db` is created automatically.
 
-## Hinzufügen neuer Server
+## Adding new servers
 
-1. Melden Sie sich mit einem Admin-Account im Webinterface an.
-2. Öffnen Sie die Seite **Serververwaltung** (`/servers`).
-3. Tragen Sie dort Alias, Hostname sowie die Admin-Zugangsdaten des Zielservers ein.
-4. Nach dem Speichern erscheint der Server in der Liste und kann Benutzern zugewiesen werden.
+1. Log in with an admin account in the web interface.
+2. Open the **Server management** page (`/servers`).
+3. Enter alias, host name and the admin credentials of the target server.
+4. After saving, the server appears in the list and can be assigned to users.
 
-Alternativ können Server auch per API angelegt werden:
+Servers can also be created via the API:
 ```bash
 curl -X POST -F alias=<alias> -F host=<host> -F admin_user=<user> -F admin_pass=<pass> http://<server>:8080/servers
 ```

--- a/agent.md
+++ b/agent.md
@@ -1,77 +1,65 @@
-# Projekt: FTPCluster - Zentrale FTP-Benutzerverwaltung mit Proxy-Mapping
+# Project: FTPCluster - Central FTP User Management with Proxy Mapping
 
-## Überblick
+## Overview
 
-FTPCluster ist eine zentrale Verwaltungsinstanz zur Benutzer- und Serververwaltung in einem verteilten FTP-Cluster. Ziel ist es, Benutzern über eine einzige IP-Adresse Zugriff auf mehrere FTP-Server zu geben, entsprechend individuell zugewiesener Rechte.
+FTPCluster acts as a central management instance for users and servers in a distributed FTP cluster. The aim is to provide users access to multiple FTP servers through a single IP address while respecting individually assigned permissions.
 
-## Hauptfunktionen
+## Main Features
 
-* Webinterface zur Verwaltung von Benutzern und Servern
-* Zentrale Authentifizierung und Benutzer-Synchronisation auf Zielservern
-* Konfigurierbares Mapping von Benutzern zu Servern
-* Reverse-Proxy-Zugriff auf entfernte Server über zentrale IP
-* Virtuelle Ordnerstruktur für Benutzerzugriff
+* Web interface for managing users and servers
+* Central authentication and user synchronization on target servers
+* Configurable mapping of users to servers
+* Reverse proxy access to remote servers via a central IP
+* Virtual folder structure for user access
 
-## Architektur
+## Architecture
 
-### Komponenten
+### Components
 
-1. **FastAPI Backend**
-
-   * REST API & HTML-Endpoints (Jinja2)
-   * Benutzerverwaltung (Anmeldung, Rechte, Sessions)
-
-2. **SQLite Datenbank**
-
-   * Tabellen: `User`, `Server`, `Permission`
-
-3. **FTP-/SFTP-Module**
-
-   * Verbindung zu Remote-Servern über `ftplib` oder `paramiko`
-
-4. **Proxy-Interface**
-
-   * Routen: `/ftp/{username}/{server_alias}/{path}`
-   * Dynamische Zugriffskontrolle pro Benutzer
-
+1. **FastAPI backend**
+   * REST API and HTML endpoints (Jinja2)
+   * User management (login, permissions, sessions)
+2. **SQLite database**
+   * Tables: `User`, `Server`, `Permission`
+3. **FTP/SFTP modules**
+   * Connection to remote servers via `ftplib` or `paramiko`
+4. **Proxy interface**
+   * Routes: `/ftp/{username}/{server_alias}/{path}`
+   * Dynamic access control per user
 5. **Frontend**
+   * Bootstrap-based UI
+   * Pages: login, dashboard, user management, server management
 
-   * Bootstrap-basiertes UI
-   * Seiten: Login, Dashboard, Benutzerverwaltung, Serververwaltung
+## Workflow
 
-## Ablauf
+1. Admin creates users and assigns them to servers
+2. Users log in through the central web interface
+3. The virtual folder structure shows assigned servers as subfolders
+4. File access is handled centrally and forwarded through the proxy
 
-1. Admin erstellt Benutzer und ordnet ihnen Server zu
-2. Benutzer meldet sich an zentraler Weboberfläche an
-3. Virtuelle Ordnerstruktur zeigt freigegebene Server als Subordner
-4. Zugriffe auf Dateien werden zentral verarbeitet und über Proxy weitergeleitet
+## Data Model
 
-## Datenmodell
-
-### Tabelle: `User`
-
+### Table: `User`
 * id (int)
 * username (str)
-* password\_hash (str)
+* password_hash (str)
 
-### Tabelle: `Server`
-
+### Table: `Server`
 * id (int)
 * alias (str)
 * host (str)
-* admin\_user (str)
-* admin\_pass (str)
+* admin_user (str)
+* admin_pass (str)
 
-### Tabelle: `Permission`
-
+### Table: `Permission`
 * id (int)
-* user\_id (FK -> User.id)
-* server\_id (FK -> Server.id)
-* user\_pass (str)
+* user_id (FK -> User.id)
+* server_id (FK -> Server.id)
+* user_pass (str)
 
-## Beispiel
+## Example
 
-**User1** hat Zugriff auf Server2 und Server3. Beim Login sieht er:
+**User1** has access to Server2 and Server3. On login they see:
 
 ```
 /home/user1/
@@ -79,74 +67,70 @@ FTPCluster ist eine zentrale Verwaltungsinstanz zur Benutzer- und Serververwaltu
 └── server3/
 ```
 
-Zugriff auf `/ftp/user1/server2/files/data.csv` wird intern über Proxy zu Server2 weitergeleitet.
+Accessing `/ftp/user1/server2/files/data.csv` is internally forwarded to Server2.
 
-## Sicherheit
+## Security
 
-* Passwort-Hashes mit bcrypt
-* JWT-Token oder session-based Auth
-* HTTPS empfohlen (uvicorn + TLS)
+* Password hashes with bcrypt
+* JWT tokens or session-based authentication
+* HTTPS recommended (uvicorn + TLS)
 
-## Erweiterungen
+## Extensions
 
-* Zwei-Faktor-Authentifizierung
-* Audit-Logging
-* API für externe Anbindung
+* Two-factor authentication
+* Audit logging
+* API for external integration
 
 ## Deployment
 
-* Systemvoraussetzungen: Python 3.11+, uvicorn, SQLite, FTP/SFTP Server
+* Requirements: Python 3.11+, uvicorn, SQLite, FTP/SFTP server
 * Start: `uvicorn main:app --host 0.0.0.0 --port 8080`
-* Optionale TLS-Konfiguration für produktive Umgebung
+* Optional TLS configuration for production
 
-## Lizenz
+## License
 
-MIT-Lizenz
+MIT License
 
 ---
 
-# Technische Dokumentation
+# Technical Documentation
 
-## Projektstruktur
+## Project Structure
 
 ```
 ftpcluster/
-├── main.py               # Einstiegspunkt, FastAPI-App mit Routing
-├── db.py                 # DB-Initialisierung & Verbindungen
-├── models.py             # SQLAlchemy-Modelle (User, Server, Permission)
-├── ftp_sync.py           # FTP-Operationen: Benutzer anlegen/löschen
-├── proxy.py              # Zugriff auf Remote-Server über zentrale Instanz
-├── templates/            # Jinja2 Templates für HTML-UI
+├── main.py               # entry point, FastAPI app with routing
+├── db.py                 # DB initialization & connections
+├── models.py             # SQLAlchemy models (User, Server, Permission)
+├── ftp_sync.py           # FTP operations: create/delete users
+├── proxy.py              # access remote servers through central instance
+├── templates/            # Jinja2 templates for HTML UI
 ├── static/               # CSS/JS
-└── README.md             # Anleitung
+└── README.md             # instructions
 ```
 
-## API-Endpunkte
+## API Endpoints
 
-### Benutzer
+### Users
+* `POST /login` - authentication
+* `GET /logout` - log out
+* `GET /users` - list users (admin)
+* `POST /users` - create user
 
-* `POST /login` - Authentifizierung
-* `GET /logout` - Logout
-* `GET /users` - Benutzerliste (Admin)
-* `POST /users` - Benutzer erstellen
+### Servers
+* `GET /servers` - list servers (admin)
+* `POST /servers` - register new server
 
-### Server
+### Permissions
+* `POST /permissions` - create user/server association
 
-* `GET /servers` - Serverliste (Admin)
-* `POST /servers` - Neuen Server registrieren
+### Proxy Access
+* `GET /ftp/{username}/{server_alias}/{path:path}` - access via central IP
 
-### Berechtigungen
-
-* `POST /permissions` - Benutzer/Server-Zuordnung erstellen
-
-### Proxy-Zugriff
-
-* `GET /ftp/{username}/{server_alias}/{path:path}` - Zugriff über zentrale IP
-
-## FTP-Logik (`ftp_sync.py`)
-
+## FTP Logic (`ftp_sync.py`)
 ```python
 from ftplib import FTP
+
 
 def create_user_on_servers(username, password, server_list):
     for srv in server_list:
@@ -154,19 +138,18 @@ def create_user_on_servers(username, password, server_list):
         ftp.login(srv.admin_user, srv.admin_pass)
         try:
             ftp.mkd(username)
-        except:
+        except Exception:
             pass
         ftp.quit()
 ```
 
 ## Reverse Proxy (`proxy.py`)
-
 ```python
 @app.get('/ftp/{user}/{srv_alias}/{path:path}')
 async def proxy_ftp(user, srv_alias, path):
     perm = db.get_permission(user, srv_alias)
     if not perm:
-        raise HTTPException(403, 'Kein Zugriff')
+        raise HTTPException(403, 'No access')
     srv = db.get_server(srv_alias)
     ftp = FTP(srv.host)
     ftp.login(user, perm.user_pass)
@@ -175,17 +158,15 @@ async def proxy_ftp(user, srv_alias, path):
     return Response(bio.getvalue(), media_type='application/octet-stream')
 ```
 
-## Datenbank-Setup (`db.py`)
-
+## Database Setup (`db.py`)
 ```python
 from sqlalchemy import create_engine
 engine = create_engine('sqlite:///ftpcluster.db')
 Base.metadata.create_all(engine)
 ```
 
-## UI-Komponenten (Jinja2)
-
-* `login.html` - Formular für Login
-* `dashboard.html` - Übersicht für Benutzer
-* `users.html` - Benutzerverwaltung
-* `servers.html` - Serververwaltung
+## UI Components (Jinja2)
+* `login.html` - login form
+* `dashboard.html` - user overview
+* `users.html` - user management
+* `servers.html` - server management

--- a/proxy.py
+++ b/proxy.py
@@ -23,7 +23,7 @@ def proxy_ftp(username: str, srv_alias: str, path: str):
     perm = get_permission(db, username, srv_alias)
     if not perm:
         db.close()
-        raise HTTPException(status_code=403, detail="Kein Zugriff")
+        raise HTTPException(status_code=403, detail="No access")
     srv = db.query(Server).filter_by(alias=srv_alias).first()
     db.close()
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,13 +5,13 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>Willkommen {{ user.username }}</h1>
-    <h2>Deine Server</h2>
+    <h1>Welcome {{ user.username }}</h1>
+    <h2>Your servers</h2>
     <ul>
         {% for perm in permissions %}
         <li>{{ perm.server.alias }}</li>
         {% else %}
-        <li>Keine Serverzuweisung</li>
+        <li>No server assignment</li>
         {% endfor %}
     </ul>
 </body>

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Serververwaltung</title>
+    <title>Server Management</title>
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>Server</h1>
+    <h1>Servers</h1>
     <form action="/servers" method="post">
         <input type="text" name="alias" placeholder="Alias" required>
         <input type="text" name="host" placeholder="Host" required>
         <input type="text" name="admin_user" placeholder="Admin User" required>
         <input type="password" name="admin_pass" placeholder="Admin Pass" required>
-        <button type="submit">Speichern</button>
+        <button type="submit">Save</button>
     </form>
 </body>
 </html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Benutzerverwaltung</title>
+    <title>User Management</title>
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>Benutzer</h1>
+    <h1>Users</h1>
     <form action="/users" method="post">
         <input type="text" name="username" placeholder="Username" required>
         <input type="password" name="password" placeholder="Password" required>
-        <button type="submit">Erstellen</button>
+        <button type="submit">Create</button>
     </form>
 </body>
 </html>

--- a/user-guide.md
+++ b/user-guide.md
@@ -1,25 +1,25 @@
 # User Guide
 
-Dieses Dokument richtet sich an reguläre Benutzer ohne Adminrechte und erklärt die Nutzung von FTPCluster.
+This document is aimed at regular users without admin rights and explains how to use FTPCluster.
 
-## Anmeldung
+## Login
 
-1. Öffnen Sie die Login-Seite der Anwendung (`/`).
-2. Geben Sie Ihren Benutzernamen und Ihr Passwort ein.
-3. Nach erfolgreichem Login werden Sie auf das Dashboard weitergeleitet.
+1. Open the application's login page (`/`).
+2. Enter your username and password.
+3. After a successful login you will be redirected to the dashboard.
 
-## Dashboard und Serverzugriff
+## Dashboard and server access
 
-- Auf dem Dashboard werden Ihnen alle Server angezeigt, auf die Sie Zugriff haben.
-- Navigieren Sie zu einem Serverordner, um Dateien über den integrierten Proxy abzurufen.
-- Datei-URLs folgen dem Schema:
+- The dashboard shows all servers you have access to.
+- Navigate to a server folder to fetch files through the integrated proxy.
+- File URLs follow the pattern:
   ```
-  /ftp/<username>/<server_alias>/<pfad/zur/datei>
+  /ftp/<username>/<server_alias>/path/to/file
   ```
-  Beispiel:
+  Example:
   ```
   /ftp/user1/server2/data/report.csv
   ```
-- Laden Sie Dateien mit einem normalen Browserdownload oder einem Kommandozeilenwerkzeug wie `curl` herunter.
+- Download files using a normal browser download or a command line tool such as `curl`.
 
-Bei Zugriffsproblemen wenden Sie sich an einen Administrator, damit die entsprechenden Berechtigungen gesetzt werden können.
+If you experience access problems, contact an administrator so the appropriate permissions can be set.


### PR DESCRIPTION
## Summary
- translate README, admin/user guide, and agent documentation to English
- update UI templates with English text
- translate German error message in proxy

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684978e1013c833398c78583648c2871