### PR TITLE
Update README and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ FTPCluster bundles user accounts, permissions and proxy access into a single dar
 
 ## Quick Start
 
-1. Install dependencies
+1. Install dependencies (now includes `python-multipart`)
 ```bash
 pip install -r requirements.txt
 ```
@@ -32,6 +32,10 @@ export MASTER_URL=http://<hostname>:8080  # URL of this instance
 3. Launch the app
 ```bash
 uvicorn main:app --host 0.0.0.0 --port 8080
+```
+4. Verify the login page
+```bash
+curl http://localhost:8080/
 ```
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ itsdangerous
 paramiko
 psutil
 requests
+python-multipart


### PR DESCRIPTION
## Summary
- document missing dependency installation in README
- add verification step to quick start
- list python-multipart in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6849e1a85a848333ae1ba9231088af18