### PR TITLE
Add SSH-based slave setup

### DIFF
--- a/admin-guide.md
+++ b/admin-guide.md
@@ -22,13 +22,36 @@ The `MASTER_URL` must point to the running instance so slave agents can post tel
 
 ---
 
+## Vorbereitung
+
+Beim Anlegen eines neuen Servers liefert der Master ein Shell-Skript, das auf
+dem Zielsystem als `root` ausgeführt wird. Dieses Skript
+
+1. legt den angegebenen Admin-Benutzer an und sperrt dessen Passwort,
+2. trägt ihn mit `NOPASSWD` in `/etc/sudoers.d/` ein,
+3. erzeugt ein SSH-Schlüsselpaar und sendet den privaten Schlüssel an den Master.
+
+Der Master speichert den Schlüssel für die zukünftige Kommunikation und
+installiert danach automatisch die benötigten Pakete sowie die Agents.
+
+Beispielablauf:
+
+```bash
+curl -F alias=meinserver -F host=10.0.0.5 http://MASTER/servers > setup.sh
+sudo bash setup.sh
+```
+
+Nach Ausführung des Skripts erscheint der Server in der Liste.
+
+---
+
 ## 2. Registering a Server
 
 1. Log in as admin and open **Servers**.
-2. Choose **Add** and provide host, alias and credentials.
-3. On save the master installs Python and an FTP server on the target, copies both agents and starts them.
-4. The datalink agent listens on port `9000` so new users can be created remotely.
-5. The new server appears in the list showing its last reported memory usage.
+2. Choose **Add** and gib Host sowie Alias an.
+3. Speichere das ausgegebene Skript auf dem Zielserver und führe es als `root` aus.
+4. Danach installiert der Master automatisch die benötigten Pakete und startet die Agents (datalink-Port 9000).
+5. Der neue Server erscheint anschließend in der Liste und zeigt seine letzte Speicherauslastung.
 
 ---
 

--- a/models.py
+++ b/models.py
@@ -18,6 +18,7 @@ class Server(Base):
     host = Column(String, nullable=False)
     admin_user = Column(String, nullable=False)
     admin_pass = Column(String, nullable=False)
+    ssh_key = Column(String, nullable=True)
     memory_usage = Column(Integer, default=0)
 
     permissions = relationship("Permission", back_populates="server")


### PR DESCRIPTION
## Summary
- replace manual prepare script with dynamic script generation
- store SSH keys for servers
- use SSH keys when connecting to slaves
- document new workflow in admin guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849eb0d7f84833381067a7bc4d8fe2f