### PR TITLE
Add repo detection to setup_master

### DIFF
--- a/setup_master.sh
+++ b/setup_master.sh
@@ -7,12 +7,25 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 DEST_DIR=/opt/ftpcluster
-SRC_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_URL="https://github.com/AsaTyr2018/ftpcluster.git"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 echo "Installing FTPCluster to $DEST_DIR"
 
-mkdir -p "$DEST_DIR"
-rsync -a --exclude='.git' "$SRC_DIR/" "$DEST_DIR/"
+if [ -d "$SCRIPT_DIR/.git" ]; then
+  echo "Detected git repository at $SCRIPT_DIR"
+  SRC_DIR="$SCRIPT_DIR"
+  mkdir -p "$DEST_DIR"
+  rsync -a --exclude='.git' "$SRC_DIR/" "$DEST_DIR/"
+else
+  SRC_DIR="$DEST_DIR"
+  if [ ! -d "$DEST_DIR/.git" ]; then
+    echo "Cloning repository from $REPO_URL to $DEST_DIR"
+    git clone "$REPO_URL" "$DEST_DIR"
+  else
+    echo "Using existing repository at $DEST_DIR"
+  fi
+fi
 
 cd "$DEST_DIR"
 


### PR DESCRIPTION
## Summary
- let `setup_master.sh` detect when it was run from a git checkout
- clone the repo if no local git data is present

## Testing
- `bash -n setup_master.sh`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f559f20c8333a7e28ef38670e23a