### PR TITLE
Fix missing python3-venv installation

### DIFF
--- a/setup_master.sh
+++ b/setup_master.sh
@@ -12,6 +12,10 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 echo "Installing FTPCluster to $DEST_DIR"
 
+# Ensure required system packages are available
+apt-get update -y
+apt-get install -y python3 python3-venv python3-pip git rsync >/dev/null
+
 if [ -d "$SCRIPT_DIR/.git" ]; then
   echo "Detected git repository at $SCRIPT_DIR"
   SRC_DIR="$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- install system packages before creating the virtual environment in `setup_master.sh`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849f7b242488333919d7dabd20d095c