### PR TITLE
Add navigation and user index

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,12 @@ async def create_user(username: str = Form(...), password: str = Form(...), db: 
     return {"id": user.id, "username": user.username}
 
 
+@app.get("/users", response_class=HTMLResponse)
+async def list_users(request: Request, db: Session = Depends(get_db)):
+    users = db.query(User).all()
+    return templates.TemplateResponse("users.html", {"request": request, "users": users})
+
+
 @app.post("/servers")
 async def create_server(alias: str = Form(...), host: str = Form(...), admin_user: str = Form("ftpadmin"), db: Session = Depends(get_db)):
     srv = Server(alias=alias, host=host, admin_user=admin_user, admin_pass="")

--- a/static/style.css
+++ b/static/style.css
@@ -44,3 +44,20 @@ ul {
 li {
     padding: 4px 0;
 }
+
+nav {
+    margin-bottom: 15px;
+}
+
+nav a {
+    color: #9ecbff;
+    text-decoration: none;
+    margin-right: 10px;
+}
+
+footer {
+    margin-top: 20px;
+    text-align: center;
+    font-size: 0.9em;
+    color: #888;
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -7,6 +7,10 @@
 <body>
     <div class="container">
         <h1>Welcome {{ user.username }}</h1>
+        <nav>
+            <a href="/servers">Servers</a> |
+            <a href="/users">Users</a>
+        </nav>
         <h2>Your servers</h2>
         <ul>
             {% for perm in permissions %}
@@ -16,5 +20,6 @@
             {% endfor %}
         </ul>
     </div>
+    <footer>&copy; Lenz-Service Network</footer>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -13,5 +13,6 @@
             <button type="submit">Login</button>
         </form>
     </div>
+    <footer>&copy; Lenz-Service Network</footer>
 </body>
 </html>

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -7,6 +7,10 @@
 <body>
     <div class="container">
         <h1>Servers</h1>
+        <nav>
+            <a href="/dashboard">Dashboard</a> |
+            <a href="/users">Users</a>
+        </nav>
         <form action="/servers" method="post">
             <input type="text" name="alias" placeholder="Alias" required>
             <input type="text" name="host" placeholder="Host" required>
@@ -22,6 +26,8 @@
             {% endfor %}
         </ul>
         {% endif %}
+        <p><a href="/dashboard">Back to Dashboard</a></p>
     </div>
+    <footer>&copy; Lenz-Service Network</footer>
 </body>
 </html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -7,11 +7,25 @@
 <body>
     <div class="container">
         <h1>Users</h1>
+        <nav>
+            <a href="/dashboard">Dashboard</a> |
+            <a href="/servers">Servers</a>
+        </nav>
         <form action="/users" method="post">
             <input type="text" name="username" placeholder="Username" required>
             <input type="password" name="password" placeholder="Password" required>
             <button type="submit">Create</button>
         </form>
+        {% if users %}
+        <h2>Existing Users</h2>
+        <ul>
+            {% for u in users %}
+            <li>{{ u.username }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        <p><a href="/dashboard">Back to Dashboard</a></p>
     </div>
+    <footer>&copy; Lenz-Service Network</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link pages together with nav sections and backlinking
- show existing users when viewing `/users`
- centralize footer with copyright notice
- style nav and footer with new CSS
- expose GET `/users` endpoint

## Testing
- `python -m py_compile main.py models.py db.py security.py server_agent.py ftp_sync.py datalink_agent.py proxy.py slave_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_684a00eee5748333867fe7f62bb50032