### PR TITLE
Pin bcrypt to maintain passlib support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 sqlalchemy
 jinja2
 passlib[bcrypt]
+bcrypt<4
 cryptography
 itsdangerous
 paramiko


### PR DESCRIPTION
## Summary
- avoid bcrypt 4.x incompatibility by pinning to `<4`

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684a020fc790833381f3b387e958bdec