### PR TITLE
Extend telemetry and dashboard metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ FTPCluster bundles user accounts, permissions and proxy access into a single dar
 | Central Accounts   | Manage users and their permissions in one place.                      |
 | Automatic Agents   | Servers receive telemetry and datalink agents via SSH on registration. |
 | Zero-Touch Setup   | Python environment and FTP server are installed automatically. |
-| Memory Dashboard   | Agents post RAM usage to the `/telemetry` endpoint.                   |
+| Usage Dashboard    | Agents post RAM, CPU, user count and disk usage to the `/telemetry` endpoint. |
 | Modern Interface   | Comfortable dark theme for daily use.                                 |
 
 ---
@@ -65,7 +65,7 @@ curl http://localhost:8080/
 ## Using the System
 
 1. Log in as admin and open **Servers**. Generate the setup script and run it on the target machine.
-2. The script installs slave and datalink agents which start reporting memory usage.
+2. The script installs slave and datalink agents which start reporting memory, CPU and disk statistics.
 3. Create users and assign them to servers.
 4. Users log in and see their permitted servers as folders.
 

--- a/agents/slave_agent.py
+++ b/agents/slave_agent.py
@@ -7,17 +7,27 @@ MASTER_URL = os.environ.get('MASTER_URL', 'http://localhost:8080')
 SERVER_ALIAS = os.environ.get('SERVER_ALIAS', 'unknown')
 
 
-def send_memory_usage():
-    usage = psutil.virtual_memory().percent
+def send_telemetry():
+    mem = psutil.virtual_memory().percent
+    cpu = psutil.cpu_percent(interval=0.5)
+    users = len(psutil.users())
+    storage = psutil.disk_usage("/").percent
+    payload = {
+        "alias": SERVER_ALIAS,
+        "mem_percent": int(mem),
+        "cpu_percent": int(cpu),
+        "user_count": users,
+        "storage_percent": int(storage),
+    }
     try:
-        requests.post(f"{MASTER_URL}/telemetry", json={"alias": SERVER_ALIAS, "mem_percent": usage})
+        requests.post(f"{MASTER_URL}/telemetry", json=payload)
     except Exception:
         pass
 
 
 def main():
     while True:
-        send_memory_usage()
+        send_telemetry()
         time.sleep(60)
 
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -51,7 +51,7 @@ After running the script, the server will appear in the list.
 2. Choose **Add** and provide host and alias.
 3. Save the generated script on the target server and run it as `root`.
 4. The master then installs the required packages and starts the agents (datalink port 9000).
-5. The new server will appear in the list and show its last reported memory usage.
+5. The new server will appear in the list and show its latest RAM, CPU, user and disk statistics.
 
 ---
 
@@ -64,6 +64,6 @@ After running the script, the server will appear in the list.
 
 ## 4. Monitoring
 
-The **Servers** page displays telemetry from agents. If a server stops reporting, check connectivity or reinstall the agent from the same page.
+The **Servers** page displays telemetry from agents including memory, CPU, connected users and disk usage. If a server stops reporting, check connectivity or reinstall the agent from the same page.
 
 Enjoy your streamlined FTP management!

--- a/main.py
+++ b/main.py
@@ -124,6 +124,9 @@ async def register_key(alias: str = Form(...), key: str = Form(...), db: Session
 class Telemetry(BaseModel):
     alias: str
     mem_percent: int
+    cpu_percent: int
+    user_count: int
+    storage_percent: int
 
 
 @app.post("/telemetry")
@@ -131,6 +134,9 @@ async def telemetry(data: Telemetry, db: Session = Depends(get_db)):
     srv = db.query(Server).filter_by(alias=data.alias).first()
     if srv:
         srv.memory_usage = data.mem_percent
+        srv.cpu_usage = data.cpu_percent
+        srv.connected_users = data.user_count
+        srv.root_usage = data.storage_percent
         db.commit()
     return {"status": "ok"}
 

--- a/models.py
+++ b/models.py
@@ -24,6 +24,9 @@ class Server(Base):
     public_key = Column(String, nullable=True)
     status = Column(String, nullable=True)
     memory_usage = Column(Integer, default=0)
+    cpu_usage = Column(Integer, default=0)
+    connected_users = Column(Integer, default=0)
+    root_usage = Column(Integer, default=0)
 
     permissions = relationship("Permission", back_populates="server")
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -14,7 +14,11 @@
         <h2>Your servers</h2>
         <ul>
             {% for perm in permissions %}
-            <li>{{ perm.server.alias }}</li>
+            <li>
+                {{ perm.server.alias }} - RAM {{ perm.server.memory_usage }}% |
+                CPU {{ perm.server.cpu_usage }}% | Users {{ perm.server.connected_users }} |
+                Disk {{ perm.server.root_usage }}%
+            </li>
             {% else %}
             <li>No server assignment</li>
             {% endfor %}

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -22,7 +22,9 @@
         <h2>Registered Servers</h2>
         <ul>
             {% for srv in servers %}
-            <li>{{ srv.alias }} - Memory {{ srv.memory_usage }}%</li>
+            <li>
+                {{ srv.alias }} - RAM {{ srv.memory_usage }}% | CPU {{ srv.cpu_usage }}% | Users {{ srv.connected_users }} | Disk {{ srv.root_usage }}%
+            </li>
             {% endfor %}
         </ul>
         {% endif %}


### PR DESCRIPTION
## Summary
- store CPU, connected users and disk statistics
- send extra telemetry data from agents
- display telemetry on dashboard and servers page
- document new metrics in README and admin guide

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a8074844c8333a399bb4f0025fe3c