### PR TITLE
Add Dockerfile with apt-based Firefox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+# Install apt-based Firefox (non-Snap)
+RUN apt-get update \
+    && apt-get install -y firefox-esr \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install python dependencies
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ FTPCluster starts automatically on boot.
 curl -s https://raw.githubusercontent.com/AsaTyr2018/ftpcluster/main/scripts/setup_master.sh | sudo bash
 ```
 
+## Docker Image
+
+This repository includes a simple Dockerfile that installs Firefox via the `firefox-esr` package.
+Build the container with:
+
+```bash
+docker build -t ftpcluster .
+```
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- add Dockerfile based on python:3.11-slim
- install Firefox via `apt` package `firefox-esr`
- document building the Docker image in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c31d2a5c08333947624a2c42c3396